### PR TITLE
Add default date to post_date in create form

### DIFF
--- a/views/pages/create.blade.php
+++ b/views/pages/create.blade.php
@@ -14,7 +14,7 @@
 
             <section class="w-2/3 pr-4">
 
-                <input type="hidden" name="post_date" value="{{ Carbon\Carbon::Now()->toDateTimeString() }}" />
+                <input type="hidden" name="post_date" value="{{ Now() }}" />
                 <input type="hidden" name="file_type" value="{{$file_type}}" />
                 <input type="hidden" name="template_name" value="{{$template_name}}" />
 

--- a/views/pages/create.blade.php
+++ b/views/pages/create.blade.php
@@ -14,7 +14,7 @@
 
             <section class="w-2/3 pr-4">
 
-                <input type="hidden" name="post_date" value="" />
+                <input type="hidden" name="post_date" value="{{ Carbon\Carbon::Now()->toDateTimeString() }}" />
                 <input type="hidden" name="file_type" value="{{$file_type}}" />
                 <input type="hidden" name="template_name" value="{{$template_name}}" />
 

--- a/views/pages/create.blade.php
+++ b/views/pages/create.blade.php
@@ -14,7 +14,7 @@
 
             <section class="w-2/3 pr-4">
 
-                <input type="hidden" name="post_date" value="{{ Now() }}" />
+                <input type="hidden" name="post_date" value="{{ now() }}" />
                 <input type="hidden" name="file_type" value="{{$file_type}}" />
                 <input type="hidden" name="template_name" value="{{$template_name}}" />
 


### PR DESCRIPTION
Add default date to post_date in create form to avoid "Attribute post_date is required" exception when submitting a new page.