### PR TITLE
Get the post_date attribute to avoid "Attribute post_date is required…

### DIFF
--- a/views/pages/edit.blade.php
+++ b/views/pages/edit.blade.php
@@ -14,7 +14,7 @@
         <div class="flex">
             <section class="w-2/3 pr-4">
 
-                <input type="hidden" name="post_date" value="" />
+                <input type="hidden" name="post_date" value="{{$page_resource->post_date}}" />
                 <input type="hidden" name="file_type" value="{{$file_type}}" />
                 <input type="hidden" name="original_url" value="{{$page_resource->url()}}" />
                 <input type="hidden" name="template_name" value="{{$page_resource->templateName()}}" />

--- a/views/pages/edit.blade.php
+++ b/views/pages/edit.blade.php
@@ -14,7 +14,7 @@
         <div class="flex">
             <section class="w-2/3 pr-4">
 
-                <input type="hidden" name="post_date" value="{{$page_resource->post_date}}" />
+                <input type="hidden" name="post_date" value="{{ $page_resource->getPostDate() ?? now() }}" />
                 <input type="hidden" name="file_type" value="{{$file_type}}" />
                 <input type="hidden" name="original_url" value="{{$page_resource->url()}}" />
                 <input type="hidden" name="template_name" value="{{$page_resource->templateName()}}" />


### PR DESCRIPTION
…" exception

In the edit page form, the post_date is required too.

So I think this fix can done the job.

But it still the question about, updated_at, created_at may be.

What do you think about this ?